### PR TITLE
added generic linux bonsai asset

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -1,6 +1,13 @@
 ---
     description: "#{repo}"
     builds:
+    - platform: "linux"
+      arch: "amd64"
+      asset_filename: "#{repo}-boutetnico_#{version}_debian9_linux_amd64.tar.gz"
+      sha_filename: "#{repo}-boutetnico_#{version}_sha512-checksums.txt"
+      filter:
+      -  "entity.system.os == 'linux'"
+      -  "entity.system.arch == 'amd64'"
     - platform: "alpine"
       arch: "amd64"
       asset_filename: "#{repo}-boutetnico_#{version}_alpine_linux_amd64.tar.gz"


### PR DESCRIPTION
The bonsai file lacked a generic asset for linux hosts. I have added that build which links to the debian9 asset. This is in line with how other bonsai assets solve the issue. For example take a look at https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-process-checks